### PR TITLE
Add requirements.txt, increase action timeout.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 540
     steps:
     - uses: actions/checkout@v1
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ __pycache__
 build/
 reports/
 
+# Python
+__pycache__*
+.pytest*
+
 # IDEs
 /.idea
 
@@ -14,3 +18,4 @@ reports/
 .env.development.local
 .env.test.local
 .env.production.local
+env*

--- a/tests/configuration/requirements.txt
+++ b/tests/configuration/requirements.txt
@@ -1,0 +1,5 @@
+# Testing
+eth-brownie
+pytest
+# Style
+black


### PR DESCRIPTION
### Description

Add a requirements.txt for simple python dependency installation: `pip install -r requirements.txt`

Also, increase the default action timeout to 9 hours, it seems the actions on this repo are terminating, due to exceeding the default time limit of 300 minutes. 

I believe this is due to improperly configured `WEB3_INFURA_PROJECT_ID` in the project's secrets. For example, I ran the tests successfuly in an action in under 3 minutes on my own repo with a proper `WEB3_INFURA_PROJECT_ID`, see it here:
https://github.com/arberx/vaults/pull/1/checks?check_run_id=1064132206

If this is in fact the case, I can open up an issue.

 